### PR TITLE
Adding Memchached to the Logstash pipeline

### DIFF
--- a/.env
+++ b/.env
@@ -50,6 +50,15 @@ API_MANAGER_PASSWORD=changeme
 LOGSTASH=logstash:5044
 
 # ----------------------------------------------------------------------------------------------
+# With this parameter you tell the Logstash processing pipeline which memchached to use. It is 
+# used to cache the API-Details that has been looked up from the API-Manager via the API-Builder.
+# Even if the API-Builder is already caching the result, this improves ingest performance. 
+# The default parameter works when using the docker-compose.yml
+# Comment this parameter if you dont want to use memcached at all.
+MEMCACHED=memchached:11211
+
+
+# ----------------------------------------------------------------------------------------------
 # This is an optional parameter used by Filebeat to set a proper name. This allows for instance 
 # to identify the different Filebeat instances in the Kibana-Stack Monitoring dashboards. 
 # Defaults to: "Filebeat Gateway"

--- a/.env
+++ b/.env
@@ -54,9 +54,7 @@ LOGSTASH=logstash:5044
 # used to cache the API-Details that has been looked up from the API-Manager via the API-Builder.
 # Even if the API-Builder is already caching the result, this improves ingest performance. 
 # The default parameter works when using the docker-compose.yml
-# Comment this parameter if you dont want to use memcached at all.
-MEMCACHED=memchached:11211
-
+MEMCACHED=memcached:11211
 
 # ----------------------------------------------------------------------------------------------
 # This is an optional parameter used by Filebeat to set a proper name. This allows for instance 

--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -17,8 +17,6 @@ jobs:
         image: memcached:1.6.6-alpine
         ports: 
           - 11211:11211
-        env:
-          MOCK_LOOKUP_API: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -37,3 +37,4 @@ jobs:
         ./logstash-filter-verifier --diff-command="diff -y" --keep-env=API_BUILDER_URL ./logstash/test ./logstash/pipeline
       env:
         API_BUILDER_URL: 'http://localhost:8080'
+        MEMCACHED: 'http://localhost:11211'

--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         echo Using API_BUILDER_URL: $API_BUILDER_URL
         echo Using MEMCACHED: $MEMCACHED
-        ./logstash-filter-verifier --diff-command="diff -y" --keep-env=API_BUILDER_URL ./logstash/test ./logstash/pipeline
+        ./logstash-filter-verifier --diff-command="diff -y" --keep-env=API_BUILDER_URL --keep-env=MEMCACHED ./logstash/test ./logstash/pipeline
       env:
         API_BUILDER_URL: 'http://localhost:8080'
         MEMCACHED: 'localhost:11211'

--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -13,6 +13,12 @@ jobs:
           - 8080:8080
         env:
           MOCK_LOOKUP_API: true
+      memcached:
+        image: memcached:1.6.6-alpine
+        ports: 
+          - 11211:11211
+        env:
+          MOCK_LOOKUP_API: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -34,7 +34,8 @@ jobs:
     - name: Test Logstash pipeline
       run: |
         echo Using API_BUILDER_URL: $API_BUILDER_URL
+        echo Using MEMCACHED: $MEMCACHED
         ./logstash-filter-verifier --diff-command="diff -y" --keep-env=API_BUILDER_URL ./logstash/test ./logstash/pipeline
       env:
         API_BUILDER_URL: 'http://localhost:8080'
-        MEMCACHED: 'http://localhost:11211'
+        MEMCACHED: 'localhost:11211'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,15 @@ services:
     depends_on:
       - elasticsearch1
       - elk-traffic-monitor-api
+      - memcached
+    networks:
+      - elastic
+
+  # Memcached is used by the Logstash pipeline to cache API-Lookup information that are used to get the API-Organization
+  memcached:
+    image: memcached:1.6.6-alpine
+    links:
+      - elasticsearch1
     networks:
       - elastic
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       - PIPELINE_WORKERS=1
       - XPACK_MONITORING_ELASTICSEARCH_HOSTS=["elasticsearch1:9200"]
       - API_BUILDER_URL=${API_BUILDER_URL}
+      - MEMCACHED=${MEMCACHED}
     ports:
       - 5044:5044
     volumes:

--- a/logstash/pipeline/pipeline.conf
+++ b/logstash/pipeline/pipeline.conf
@@ -66,13 +66,13 @@ filter {
       }
       # If we have a ServiceConext we have to enrich it with the API-Details
       if([transactionSummary][serviceContext]) {
-        # Create a key for the API
+          # Create a key for the API
         mutate {
           add_field => { "apiCacheKey" => "%{[transactionSummary][path]}" }
         }
         # Lookup the cache with the created API-Key (API-Name---API-Path)
         memcached {
-          hosts => ["memcached"]
+          hosts => "${MEMCACHED}"
           namespace => "api_details"
           get => { "%{apiCacheKey}" => "[apiDetails]" }
         }
@@ -85,7 +85,7 @@ filter {
               "apiPath" => "%{[transactionSummary][path]}"
             }
             target_body => "apiDetails"
-            add_field => { "updateAPICache" => "true" }
+            add_field => { "[@metadata][updateAPICache]" => "true" }
           }
         }
         # At this point we should have the apiDetails either from the cache or looked up via HTTP
@@ -99,9 +99,9 @@ filter {
             }
           }
           # If the API has been looked up add it to the cache
-          if([updateAPICache]=="true") {
+          if([@metadata][updateAPICache]=="true") {
             memcached {
-              hosts => ["memcached"]
+              hosts => "${MEMCACHED}"
               namespace => "api_details"
               ttl => 3600
               set => { "[apiDetails]" => "%{apiCacheKey}" }

--- a/logstash/pipeline/pipeline.conf
+++ b/logstash/pipeline/pipeline.conf
@@ -64,21 +64,20 @@ filter {
        remove_field => "[transactionSummary][serviceContexts]"
        rename => ["[transactionSummary][serviceContext][org]", "[transactionSummary][serviceContext][appOrg]" ]
       }
-      # Create a key for the API
-      mutate {
-        add_field => { "apiCacheKey" => "%{[transactionSummary][serviceContext][service]}---%{[transactionSummary][path]}" }
-      }
-      memcached {
-        hosts => ["memcached"]
-        namespace => "api_details"
-        ttl => 300
-        get => { "apiCacheKey" => "[transactionSummary][serviceContext][apiOrg]" }
-        remove_field => [ "apiCacheKey" ]
-      }
-      # If the apiOrg is already set, the information has been loaded before from memcached 
-      if ![transactionSummary][serviceContext][apiOrg] {
-        # Perform a side-call to load organization details for the API
-        if([transactionSummary][serviceContext]) {
+      # If we have a ServiceConext we have to enrich it with the API-Details
+      if([transactionSummary][serviceContext]) {
+        # Create a key for the API
+        mutate {
+          add_field => { "apiCacheKey" => "%{[transactionSummary][path]}" }
+        }
+        # Lookup the cache with the created API-Key (API-Name---API-Path)
+        memcached {
+          hosts => ["memcached"]
+          namespace => "api_details"
+          get => { "%{apiCacheKey}" => "[apiDetails]" }
+        }
+        # If we have nothing in the cache, perform the Lookup via the HTTP-Builder API
+        if !([apiDetails]) {
           http {
             url => "${API_BUILDER_URL}/api/elk/v1/api/lookup/api"
             query => {
@@ -86,31 +85,48 @@ filter {
               "apiPath" => "%{[transactionSummary][path]}"
             }
             target_body => "apiDetails"
+            add_field => { "updateAPICache" => "true" }
+          }
+        }
+        # At this point we should have the apiDetails either from the cache or looked up via HTTP
+        if([apiDetails]) {
+          mutate {
             add_field => { 
               "[transactionSummary][serviceContext][apiOrg]" => "%{[apiDetails][organizationName]}"
               "[transactionSummary][serviceContext][apiVersion]" => "%{[apiDetails][version]}" 
               "[transactionSummary][serviceContext][apiDeprecated]" => "%{[apiDetails][deprecated]}" 
               "[transactionSummary][serviceContext][apiState]" => "%{[apiDetails][state]}"
             }
-            remove_field => [ "apiDetails", "headers" ]
           }
-          # If the API-Lookup failed - Clone the event which is send to an Error index and shown in Traffic-Monitor
-          if("_httprequestfailure" in [tags]) {
-            clone {
-              clones => ['errorEvent']
+          # If the API has been looked up add it to the cache
+          if([updateAPICache]=="true") {
+            memcached {
+              hosts => ["memcached"]
+              namespace => "api_details"
+              ttl => 3600
+              set => { "[apiDetails]" => "%{apiCacheKey}" }
             }
-            if [type] == 'errorEvent' {
-              # Fill the URI based on the given path to have it shown in Traffic-Monitor
-              mutate { add_field => { "[transactionElements][leg0][protocolInfo][http][uri]" => "%{[transactionSummary][path]}" } }
-              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][vhost]" => "Logstash Error" } }
-              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][method]" => "LOGSTASH" } }
-              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][status]" => "900" } }
-              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][statusText]" => "ERROR" } }
-              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][authSubjectId]" => "ID: %{[correlationId]}" } }
-              mutate { replace => { "[transactionSummary][serviceContext][method]" => "check the logs" } }
-              # Make sure, the Correlation-ID is unique to avoid an update of the original document
-              mutate { replace => { "[correlationId]" => "%{[correlationId]}-Error" } }
-            }
+          }
+        }
+        mutate {
+          remove_field => [ "apiDetails", "headers", "updateAPICache", "apiCacheKey" ]
+        }
+        # If the API-Lookup failed - Clone the event which is send to an Error index and shown in Traffic-Monitor
+        if("_httprequestfailure" in [tags]) {
+          clone {
+            clones => ['errorEvent']
+          }
+          if [type] == 'errorEvent' {
+            # Fill the URI based on the given path to have it shown in Traffic-Monitor
+            mutate { add_field => { "[transactionElements][leg0][protocolInfo][http][uri]" => "%{[transactionSummary][path]}" } }
+            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][vhost]" => "Logstash Error" } }
+            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][method]" => "LOGSTASH" } }
+            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][status]" => "900" } }
+            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][statusText]" => "ERROR" } }
+            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][authSubjectId]" => "ID: %{[correlationId]}" } }
+            mutate { replace => { "[transactionSummary][serviceContext][method]" => "check the logs" } }
+            # Make sure, the Correlation-ID is unique to avoid an update of the original document
+            mutate { replace => { "[correlationId]" => "%{[correlationId]}-Error" } }
           }
         }
       }

--- a/logstash/pipeline/pipeline.conf
+++ b/logstash/pipeline/pipeline.conf
@@ -64,54 +64,56 @@ filter {
        remove_field => "[transactionSummary][serviceContexts]"
        rename => ["[transactionSummary][serviceContext][org]", "[transactionSummary][serviceContext][appOrg]" ]
       }
-      # Future plan is to perform side-calls only if not yet already cached
-      #mutate {
-      #  add_field => { "apiCacheKey" => "%{[transactionSummary][serviceContext][service]}---%{[transactionSummary][path]}" }
-      #}
-      #memcached {
-      #  namespace => "api_details"
-      #  ttl => 300
-      #  get => { "apiCacheKey" => "[transactionSummary][serviceContext][serviceOrg]" }
-      #  remove_field => [ "apiCacheKey" ]
-      #}
-      #if ![transactionSummary][serviceContext][serviceOrg] {
-      # Perform a side-call to load organization details for the API
-      if([transactionSummary][serviceContext]) {
-        http {
-          url => "${API_BUILDER_URL}/api/elk/v1/api/lookup/api"
-          query => {
-            "apiName" => "%{[transactionSummary][serviceContext][service]}"
-            "apiPath" => "%{[transactionSummary][path]}"
+      # Create a key for the API
+      mutate {
+        add_field => { "apiCacheKey" => "%{[transactionSummary][serviceContext][service]}---%{[transactionSummary][path]}" }
+      }
+      memcached {
+        hosts => ["memcached"]
+        namespace => "api_details"
+        ttl => 300
+        get => { "apiCacheKey" => "[transactionSummary][serviceContext][apiOrg]" }
+        remove_field => [ "apiCacheKey" ]
+      }
+      # If the apiOrg is already set, the information has been loaded before from memcached 
+      if ![transactionSummary][serviceContext][apiOrg] {
+        # Perform a side-call to load organization details for the API
+        if([transactionSummary][serviceContext]) {
+          http {
+            url => "${API_BUILDER_URL}/api/elk/v1/api/lookup/api"
+            query => {
+              "apiName" => "%{[transactionSummary][serviceContext][service]}"
+              "apiPath" => "%{[transactionSummary][path]}"
+            }
+            target_body => "apiDetails"
+            add_field => { 
+              "[transactionSummary][serviceContext][apiOrg]" => "%{[apiDetails][organizationName]}"
+              "[transactionSummary][serviceContext][apiVersion]" => "%{[apiDetails][version]}" 
+              "[transactionSummary][serviceContext][apiDeprecated]" => "%{[apiDetails][deprecated]}" 
+              "[transactionSummary][serviceContext][apiState]" => "%{[apiDetails][state]}"
+            }
+            remove_field => [ "apiDetails", "headers" ]
           }
-          target_body => "apiDetails"
-          add_field => { 
-            "[transactionSummary][serviceContext][apiOrg]" => "%{[apiDetails][organizationName]}"
-            "[transactionSummary][serviceContext][apiVersion]" => "%{[apiDetails][version]}" 
-            "[transactionSummary][serviceContext][apiDeprecated]" => "%{[apiDetails][deprecated]}" 
-            "[transactionSummary][serviceContext][apiState]" => "%{[apiDetails][state]}"
-          }
-          remove_field => [ "apiDetails", "headers" ]
-        }
-        # If the API-Lookup failed - Clone the event which is send to an Error index and shown in Traffic-Monitor
-        if("_httprequestfailure" in [tags]) {
-          clone {
-            clones => ['errorEvent']
-          }
-          if [type] == 'errorEvent' {
-            # Fill the URI based on the given path to have it shown in Traffic-Monitor
-            mutate { add_field => { "[transactionElements][leg0][protocolInfo][http][uri]" => "%{[transactionSummary][path]}" } }
-            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][vhost]" => "Logstash Error" } }
-            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][method]" => "LOGSTASH" } }
-            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][status]" => "900" } }
-            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][statusText]" => "ERROR" } }
-            mutate { replace => { "[transactionElements][leg0][protocolInfo][http][authSubjectId]" => "ID: %{[correlationId]}" } }
-            mutate { replace => { "[transactionSummary][serviceContext][method]" => "check the logs" } }
-            # Make sure, the Correlation-ID is unique to avoid an update of the original document
-            mutate { replace => { "[correlationId]" => "%{[correlationId]}-Error" } }
+          # If the API-Lookup failed - Clone the event which is send to an Error index and shown in Traffic-Monitor
+          if("_httprequestfailure" in [tags]) {
+            clone {
+              clones => ['errorEvent']
+            }
+            if [type] == 'errorEvent' {
+              # Fill the URI based on the given path to have it shown in Traffic-Monitor
+              mutate { add_field => { "[transactionElements][leg0][protocolInfo][http][uri]" => "%{[transactionSummary][path]}" } }
+              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][vhost]" => "Logstash Error" } }
+              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][method]" => "LOGSTASH" } }
+              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][status]" => "900" } }
+              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][statusText]" => "ERROR" } }
+              mutate { replace => { "[transactionElements][leg0][protocolInfo][http][authSubjectId]" => "ID: %{[correlationId]}" } }
+              mutate { replace => { "[transactionSummary][serviceContext][method]" => "check the logs" } }
+              # Make sure, the Correlation-ID is unique to avoid an update of the original document
+              mutate { replace => { "[correlationId]" => "%{[correlationId]}-Error" } }
+            }
           }
         }
       }
-      #}
     }
   } else if([logtype] == "trace") {
     if [message] =~ /^#/ {


### PR DESCRIPTION
With this feature, the Logstash pipeline is making sidecalls to the API-Builder API-Details-Look-Up API only once per API-Path. This improves ingest performance.